### PR TITLE
Add `Vale` for linting prose

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -16,3 +16,8 @@ jobs:
       - uses: paddyroddy/.github/actions/linting@232a2f3869501abb249d50e311179f98830c6481 # v0
         with:
           pre-commit-config: ./.pre-commit-config.yaml
+
+      # yamllint disable-line rule:line-length
+      - uses: paddyroddy/.github/actions/vale@d5aea086eaabccae4bcf39786ad5138b629755a6 # v0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+!.github/styles/config/
+!.github/styles/config/vocabularies/
+!.github/styles/config/vocabularies/Base
+.github/styles/*
+.github/styles/config/*
+.github/styles/config/vocabularies/*

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,30 @@
+StylesPath = .github/styles
+
+# https://github.com/errata-ai/packages
+Packages = proselint,\
+           write-good
+
+[formats]
+twee = md
+
+[*.{md,twee}]
+BasedOnStyles = proselint,\
+                Vale,\
+                write-good
+
+# Disable
+Vale.Spelling = NO
+write-good.E-Prime = NO
+write-good.Passive = NO
+write-good.TooWordy = NO
+
+# Ignore lines starting with GitHub alerts syntax
+BlockIgnores = (?s)> \[!(CAUTION|IMPORTANT|NOTE|TIP|WARNING)\](\n|$)
+
+# `vale sync` in CI means the packages are then linted, so turn them off
+[.github/styles/**]
+BasedOnStyles =
+
+# Don't modify generated files
+[**/{CODE_OF_CONDUCT,LICENSE}*]
+BasedOnStyles =

--- a/story/choose-a-database.twee
+++ b/story/choose-a-database.twee
@@ -124,7 +124,7 @@ Is your data media files? (Video, pictures, PDFs, specialised formats like nifti
 
 :: network-yes {"position":"1050,1050","size":"100,100"}
 The wizard calls his familiar, a large fuzzy spider. It hands you a magical spider web which speeds up the process of cataloguing the spells.
- 
+
  Consider using a <a href="https://en.wikipedia.org/wiki/Graph_database">Graph database</a>.
 
 

--- a/story/choose-a-database.twee
+++ b/story/choose-a-database.twee
@@ -61,16 +61,16 @@ Can you structure your data well in rows and columns?
 
 
 :: explore-no {"position":"1325,825","size":"100,100"}
-But you said you didn't know what questions to ask!
+You said you didn't know what questions to ask!
 
 If you know your wishes, [[ask the genie|question-yes]]!
 
 
 
 :: explore-yes {"position":"1325,925","size":"100,100"}
-You put the lamp in your pack and continue down the road. After some time you arrive at a watering hole. There is a friendly looking elephant drinking, and a dolphin pops its head above the water.
+You put the lamp in your pack and continue down the road. After some time you arrive at a watering hole. A friendly looking elephant is drinking, and a dolphin pops its head above the water.
 
-...choose a <a href="https://en.wikipedia.org/wiki/Relational_database">relational DB</a>.
+…choose a <a href="https://en.wikipedia.org/wiki/Relational_database">relational DB</a>.
 
 Popular choices: Postgres and MySQL.
 
@@ -179,7 +179,7 @@ Do you know exactly what question to ask? (For example, how many students have a
 
 
 :: text-no {"position":"900,1475","size":"100,100"}
-You find a mysterious map in the library. After following it, you arrive at a watering hole. There is a friendly looking elephant drinking, and a dolphin pops its head above the water.
+You find a mysterious map in the library. After following it, you arrive at a watering hole, where a friendly looking elephant is drinking and a dolphin pops its head above the water.
 
 Use a <a href="https://en.wikipedia.org/wiki/Relational_database">relational database</a>. Popular choices: <a href="https://en.wikipedia.org/wiki/PostgreSQL">Postgres</a> and <a href="https://en.wikipedia.org/wiki/MySQL">MySQL</a>.
 


### PR DESCRIPTION
In this PR I add [vale](https://vale.sh/) similarly to https://github.com/paddyroddy/talks/pull/80, https://github.com/paddyroddy/talks/pull/82, https://github.com/UCL-ARC/python-tooling/pull/541. See this blog post for an explanation of what it is https://www.datadoghq.com/blog/engineering/how-we-use-vale-to-improve-our-documentation-editing-process. I used this extensively during my PhD https://github.com/paddyroddy/phd-thesis/blob/main/.vale.ini. I recently gave a talk about this in the Collaboration Hour, slides here: https://paddyroddy.github.io/talks/linting-prose-with-vale.

I have also fixed the few cases with the limited rules I've selected.